### PR TITLE
Commits should stay in chronological order within groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,7 @@ Changelog.prototype.getLog = function( callback ) {
 };
 
 Changelog.prototype.parseCommits = function( commits ) {
+	var component = /^(.+):/;
 	commits = commits.split( "__COMMIT__\n" );
 	commits.shift();
 
@@ -61,7 +62,14 @@ Changelog.prototype.parseCommits = function( commits ) {
 		.map( this.parseCommit )
 
 		// Sort commits so that they're grouped by component
-		.sort()
+		.sort(function( a, b ) {
+			var aMatch = a.match( component ),
+				bMatch = b.match( component );
+			if ( aMatch && bMatch) {
+				return aMatch[ 1 ].localeCompare( bMatch[ 1 ] );
+			}
+			return a.localeCompare( b );
+		})
 		.join( "\n" ) + "\n";
 };
 

--- a/tests/changelog.js
+++ b/tests/changelog.js
@@ -106,10 +106,10 @@ exports.parseCommits = {
 	},
 
 	commits: function( test ) {
-		test.expect( 4 );
+		test.expect( 5 );
 
-		var providedCommits = [ "a", "c", "b" ];
-		var parsedCommits = [ "a", "c", "b" ];
+		var providedCommits = [ "a: y", "a: x", "c", "b" ];
+		var parsedCommits = [ "a: y", "a: x", "c", "b" ];
 		var providedCommitsLog = "__COMMIT__\n" +
 			providedCommits.join( "__COMMIT__\n" );
 		var callCount = 0;
@@ -127,7 +127,7 @@ exports.parseCommits = {
 
 		test.strictEqual(
 			this.changelog.parseCommits( providedCommitsLog ),
-			"a\nb\nc\n",
+			"a: y\na: x\nb\nc\n",
 			"Should parse and sort commits."
 		);
 		test.done();


### PR DESCRIPTION
Fixes #2

When one of the two doesn't have a component, it orders as before. Still orders correctly within a group, so that seems fine.
